### PR TITLE
Update samples to use the 1.1.2 CloudHSM JCE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
                         <configuration>
                             <groupId>com.cavium</groupId>
                             <artifactId>cloudhsm</artifactId>
-                            <version>1.1.1</version>
+                            <version>1.1.2</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/cloudhsm-1.1.1.jar</file>
+                            <file>/opt/cloudhsm/java/cloudhsm-1.1.2.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -350,7 +350,7 @@
         <dependency>
             <groupId>com.cavium</groupId>
             <artifactId>cloudhsm</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the 1.1.2 version by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
