### PR TITLE
Add examples of importing EC and RSA keys to the Key Utility runner.

### DIFF
--- a/src/main/java/com/amazonaws/cloudhsm/examples/AsymmetricKeys.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/AsymmetricKeys.java
@@ -50,6 +50,11 @@ public class AsymmetricKeys {
         boolean isExtractable = false;
         boolean isPersistent = false;
 
+        return generateECKeyPairWithParams(curveName, label, isExtractable, isPersistent);
+    }
+
+    public KeyPair generateECKeyPairWithParams(String curveName, String label, boolean isExtractable, boolean isPersistent)
+            throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException {
 
         KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("EC", "Cavium");
         keyPairGen.initialize(
@@ -77,6 +82,12 @@ public class AsymmetricKeys {
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException {
         boolean isExtractable = false;
         boolean isPersistent = false;
+
+        return generateRSAKeyPairWithParams(keySizeInBits, label, isExtractable, isPersistent);
+    }
+
+    public KeyPair generateRSAKeyPairWithParams(int keySizeInBits, String label, boolean isExtractable, boolean isPersistent)
+            throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException {
 
         KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("rsa", "Cavium");;
         CaviumRSAKeyGenParameterSpec spec = new CaviumRSAKeyGenParameterSpec(keySizeInBits, new BigInteger("65537"), label + ":public", label + ":private", isExtractable, isPersistent);

--- a/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
@@ -21,6 +21,7 @@ import com.cavium.cfm2.ImportKey;
 import com.cavium.cfm2.Util;
 import com.cavium.key.*;
 import com.cavium.key.parameter.CaviumKeyGenAlgorithmParameterSpec;
+import com.cavium.key.parameter.CaviumECGenParameterSpec;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.KeyGenerator;
@@ -131,8 +132,21 @@ public class KeyUtilitiesRunner {
 
                     // Import the key as a session key that is extractable.
                     // You can use the key handle to identify the key in other operations.
-                    Key importedKey = importKey(keyToBeImported, "Test", true, false);
+                    Key importedKey = importKey(keyToBeImported, "Test", false, false);
                     displayKeyInfo((CaviumKey) importedKey);
+
+                    // Generate an extractable session EC keypair and import the private key.
+                    KeyPair ecPair = new AsymmetricKeys().generateECKeyPairWithParams(CaviumECGenParameterSpec.PRIME256V1, "ectest", true, false);
+                    Key k = exportKey(((CaviumKey)ecPair.getPrivate()).getHandle());
+                    importedKey = importKey(k, "EC Import Test", false, false);
+                    displayKeyInfo((CaviumKey) importedKey);
+
+                    // Generate an extractable session RSA keypair and import the private key.
+                    KeyPair rsaPair = new AsymmetricKeys().generateRSAKeyPairWithParams(2048, "rsatest", true, false);
+                    k = exportKey(((CaviumKey)rsaPair.getPrivate()).getHandle());
+                    importedKey = importKey(k, "RSA Import Test", false, false);
+                    displayKeyInfo((CaviumKey) importedKey);
+
                     break;
                 }
                 case GET_KEY: {
@@ -226,6 +240,13 @@ public class KeyUtilitiesRunner {
             }
             else if(cka.getKeyType() == CaviumKeyAttributes.KEY_TYPE_RSA && cka.getKeyClass() == CaviumKeyAttributes.CLASS_PUBLIC_KEY) {
                 PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(encoded));
+                return publicKey;
+            } else if(cka.getKeyType() == CaviumKeyAttributes.KEY_TYPE_EC && cka.getKeyClass() == CaviumKeyAttributes.CLASS_PRIVATE_KEY) {
+                PrivateKey privateKey = KeyFactory.getInstance("EC").generatePrivate(new PKCS8EncodedKeySpec(encoded));
+                return privateKey;
+            }
+            else if(cka.getKeyType() == CaviumKeyAttributes.KEY_TYPE_EC && cka.getKeyClass() == CaviumKeyAttributes.CLASS_PUBLIC_KEY) {
+                PublicKey publicKey = KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(encoded));
                 return publicKey;
             }
         } catch (BadPaddingException | CFM2Exception e) {


### PR DESCRIPTION
*Description of changes:*

Add examples of importing EC and RSA keys to the Key Utility runner.
Allow more control over extractability and persistence when creating Asymmetric key pairs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
