### PR TITLE
Dynamic CloudHSM version and jar file in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
             </activation>
             <properties>
                 <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.0.jar</cloudhsmJarPath>
+                <cloudhsmVersion>2.0.0</cloudhsmVersion>
             </properties>
         </profile>
     </profiles>
@@ -70,7 +71,7 @@
                         <configuration>
                             <groupId>com.cavium</groupId>
                             <artifactId>cloudhsm</artifactId>
-                            <version>2.0.0</version>
+                            <version>${cloudhsmVersion}</version>
                             <packaging>jar</packaging>
                             <file>${cloudhsmJarPath}</file>
                             <generatePom>true</generatePom>
@@ -617,7 +618,7 @@
         <dependency>
             <groupId>com.cavium</groupId>
             <artifactId>cloudhsm</artifactId>
-            <version>2.0.0</version>
+            <version>${cloudhsmVersion}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,18 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>default-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.0.jar</cloudhsmJarPath>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -60,7 +72,7 @@
                             <artifactId>cloudhsm</artifactId>
                             <version>2.0.0</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/cloudhsm-2.0.0.jar</file>
+                            <file>${cloudhsmJarPath}</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.0.jar</cloudhsmJarPath>
-                <cloudhsmVersion>2.0.0</cloudhsmVersion>
+                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.3.jar</cloudhsmJarPath>
+                <cloudhsmVersion>2.0.3</cloudhsmVersion>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
The CloudHSM version and jar file was hardcoded in pom file to 2.0.0
Add variables (CLOUDHSM_JAR_PATH and CLOUDHSM_VERSION) to specify custom version and jar files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
