### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.3.jar</cloudhsmJarPath>
-                <cloudhsmVersion>2.0.3</cloudhsmVersion>
+                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-2.0.4.jar</cloudhsmJarPath>
+                <cloudhsmVersion>2.0.4</cloudhsmVersion>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Update pom.xml to CloudHSM client and JCE version 2.0.4

*Issue #, if available: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file (install-cloudhsm-jce) on project aws-cloudhsm-jce-examples: The specified file '/opt/cloudhsm/java/cloudhsm-2.0.3.jar' not exists -> [Help 1]

*Description of changes: Updated the cloudhsmJarPath and cloudhsmVersion to 2.0.4 coinciding with the latest client releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
