### PR TITLE
Added example to find all keys for current user

### DIFF
--- a/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
@@ -49,6 +49,7 @@ public class KeyUtilitiesRunner {
             "Options\n" +
             "\t[--label <key label>] [--handle <numeric key handle>]\n" +
             "\t--get-key\t\tGet information about a key in the HSM\n" +
+            "\t--get-all-keys\t\tGet all keys for the current user\n" +
             "\t--delete-key\t\tDelete a key from the HSM\n" +
             "\t--import-key\t\tGenerates a key locally and imports it into the HSM\n" +
             "\t--import-rsa-pem\t\tRead a PEM file and import the private key\n" +
@@ -57,6 +58,7 @@ public class KeyUtilitiesRunner {
     private enum modes {
         INVALID,
         GET_KEY,
+        GET_ALL_KEYS,
         DELETE_KEY,
         EXPORT_KEY,
         IMPORT_KEY,
@@ -89,6 +91,9 @@ public class KeyUtilitiesRunner {
                 case "--get-key":
                     mode = modes.GET_KEY;
                     break;
+                case "--get-all-keys":
+                    mode = modes.GET_ALL_KEYS;
+                    break;
                 case "--delete-key":
                     mode = modes.DELETE_KEY;
                     break;
@@ -103,6 +108,17 @@ public class KeyUtilitiesRunner {
                     mode = modes.IMPORT_PEM;
                     break;
             }
+        }
+
+        if (mode == modes.GET_ALL_KEYS) {
+            System.out.format("%-12s%-64s%-12s%-12s%-12s%-12s\n\n", "KeyHandle", "Label", "Persistent", 
+                                "Extractable", "Algo", "Size");
+            for(Enumeration<CaviumKey> keys = Util.findAllKeys(label); keys.hasMoreElements();) {
+                CaviumKey k = keys.nextElement();
+                System.out.format("%-12d%-64s%-12s%-12s%-12s%-12s\n", k.getHandle(), k.getLabel(), 
+                                    k.isPersistent(), k.isExtractable(), k.getAlgorithm(), k.getSize());
+            }
+            return;
         }
 
         if (null != label && 0 != handle) {

--- a/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
@@ -37,6 +37,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+import java.util.Enumeration;
 
 /**
  * This sample demonstrates how to work with keys. This could be importing keys, exporting keys, loading keys by handle,
@@ -64,6 +65,8 @@ public class KeyUtilitiesRunner {
         IMPORT_KEY,
         IMPORT_PEM
     }
+
+    private static String formatStringForKeyDetails = "%-12s%-12s%-12s%-12s%-12s%s\n";
 
     public static void main(String[] args) throws Exception {
         try {
@@ -110,46 +113,37 @@ public class KeyUtilitiesRunner {
             }
         }
 
-        if (mode == modes.GET_ALL_KEYS) {
-            System.out.format("%-12s%-64s%-12s%-12s%-12s%-12s\n\n", "KeyHandle", "Label", "Persistent", 
-                                "Extractable", "Algo", "Size");
-            for(Enumeration<CaviumKey> keys = Util.findAllKeys(label); keys.hasMoreElements();) {
-                CaviumKey k = keys.nextElement();
-                System.out.format("%-12d%-64s%-12s%-12s%-12s%-12s\n", k.getHandle(), k.getLabel(), 
-                                    k.isPersistent(), k.isExtractable(), k.getAlgorithm(), k.getSize());
+        if (mode != modes.GET_ALL_KEYS) {
+            if (null != label && 0 != handle) {
+                System.out.println("Please specify one of key handle or label");
+                help();
+                return;
+            } else if (null == label && 0 == handle && modes.IMPORT_KEY != mode && modes.IMPORT_PEM != mode) {
+                System.out.println("Please specify either key handle or label");
+                help();
+                return;
+            } else if (modes.IMPORT_PEM == mode && null == pemFile) {
+                System.out.println("Please specify the PEM file name");
+                help();
+                return;
             }
-            return;
-        }
 
-        if (null != label && 0 != handle) {
-            System.out.println("Please specify one of key handle or label");
-            help();
-            return;
-        } else if (null == label && 0 == handle && modes.IMPORT_KEY != mode && modes.IMPORT_PEM != mode) {
-            System.out.println("Please specify either key handle or label");
-            help();
-            return;
-        } else if (modes.IMPORT_PEM == mode && null == pemFile) {
-            System.out.println("Please specify the PEM file name");
-            help();
-            return;
-        }
+            // Using the supplied label, find the associated key handle.
+            // The handle for the *first* key found using the label will be the handle returned.
+            // If multiple keys have the same label, only the first key can be returned.
+            if (0 == handle && modes.IMPORT_KEY != mode && modes.IMPORT_PEM != mode) {
+                try {
+                    long[] handles = { 0 };
+                    Util.findKey(label, handles);
+                    handle = handles[0];
+                } catch (CFM2Exception ex) {
+                    if (CFM2Exception.isAuthenticationFailure(ex)) {
+                        System.out.println("Could not find credentials to login to the HSM");
+                        return;
+                    }
 
-        // Using the supplied label, find the associated key handle.
-        // The handle for the *first* key found using the label will be the handle returned.
-        // If multiple keys have the same label, only the first key can be returned.
-        if (0 == handle && modes.IMPORT_KEY != mode && modes.IMPORT_PEM != mode) {
-            try {
-                long[] handles = { 0 };
-                Util.findKey(label, handles);
-                handle = handles[0];
-            } catch (CFM2Exception ex) {
-                if (CFM2Exception.isAuthenticationFailure(ex)) {
-                    System.out.println("Could not find credentials to login to the HSM");
-                    return;
+                    throw ex;
                 }
-
-                throw ex;
             }
         }
 
@@ -195,6 +189,16 @@ public class KeyUtilitiesRunner {
                         displayKeyInfo(key);
                     } else {
                         System.out.println("Could not find the given key handle");
+                    }
+                    break;
+                }
+                case GET_ALL_KEYS: {
+                    System.out.format(formatStringForKeyDetails, "KeyHandle", "Persistent",
+                                "Extractable", "Algo", "Size", "Label");
+                    for(Enumeration<CaviumKey> keys = Util.findAllKeys(label); keys.hasMoreElements();) {
+                        CaviumKey k = keys.nextElement();
+                        System.out.format(formatStringForKeyDetails, k.getHandle(), k.isPersistent(),
+                                            k.isExtractable(), k.getAlgorithm(), k.getSize(), k.getLabel());
                     }
                     break;
                 }


### PR DESCRIPTION
*Description of changes:*
Added example to find all keys for the current user

*Example output:*
```
KeyHandle   Persistent  Extractable Algo        Size        Label
524294      true        true        AES         128         tmp111
786439      true        true        AES         128         testv3_1
786440      true        true        AES         128         testv1_1
524297      true        true        AES         128         temp333
2621450     true        true        AES         256
1310731     true        true        RSA         2048        RSAPrivate
2621452     true        true        RSA         2048
2621453     true        true        EC          256
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
