### PR TITLE
AESWrapping sample now works for AESWrap/ECB/* mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This sample code is made available under a modified MIT license. See the LICENSE
 
 ### Dependencies
 
-The CloudHSM Client and JCE dependencies are required. They should be installed using the official
-procedures documented here:
+The latest version of CloudHSM Client and JCE dependencies are required.
+They should be installed using the official procedures documented here:
 
 * https://docs.aws.amazon.com/cloudhsm/latest/userguide/java-library-install.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-3.0.0.jar</cloudhsmJarPath>
-                <cloudhsmVersion>3.0.0</cloudhsmVersion>
+                <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-3.1.0.jar</cloudhsmJarPath>
+                <cloudhsmVersion>3.1.0</cloudhsmVersion>
             </properties>
         </profile>
     </profiles>

--- a/src/main/java/com/amazonaws/cloudhsm/examples/AESWrappingRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/AESWrappingRunner.java
@@ -97,33 +97,22 @@ public class AESWrappingRunner {
         cipher.init(Cipher.WRAP_MODE, hsmWrappingKey);
 
         // Wrap the extractable key using the wrappingKey
-        byte[] hsmWrappedBytes = cipher.wrap(extractableKey);
+        byte[] wrappedBytes = cipher.wrap(extractableKey);
 
-        // Unwrap the wrapped key using the wrapping key
+        // Unwrap using hsm
         cipher.init(Cipher.UNWRAP_MODE, hsmWrappingKey);
-        Key hsmUnwrappedExtractableKey = cipher.unwrap(hsmWrappedBytes, "AES", Cipher.SECRET_KEY);
+        Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
 
         // Compare original key with HSM unwrapped key
-        assert (Arrays.equals(extractableKey.getEncoded(), hsmUnwrappedExtractableKey.getEncoded()));
+        assert (Arrays.equals(extractableKey.getEncoded(), unwrappedExtractableKey.getEncoded()));
         System.out.printf("\nVerified key when using the HSM to wrap and unwrap with AESWrap/ECB/NoPadding:\n %s\n",
-                            Base64.getEncoder().encodeToString(hsmUnwrappedExtractableKey.getEncoded()));
+                            Base64.getEncoder().encodeToString(unwrappedExtractableKey.getEncoded()));
 
-        // Create a SunJCE provider cipher instance to unwrap the key
-        Cipher sunCipher = Cipher.getInstance("AESWrap", "SunJCE");
-
-        // Unwrap the hsm wrapped key using SunJCE
-        sunCipher.init(Cipher.UNWRAP_MODE, sunJceWrappingKey);
-        Key sunJceUnwrappedExtractableKey = sunCipher.unwrap(hsmWrappedBytes, "AES", Cipher.SECRET_KEY);
-
-        // Compare original key with SunJCE unwrapped key
-        assert (Arrays.equals(extractableKey.getEncoded(), sunJceUnwrappedExtractableKey.getEncoded()));
-        System.out.printf("\nVerified key when using the HSM to wrap and SunJCE to unwrap with AESWrap/ECB/NoPadding:\n %s\n",
-                            Base64.getEncoder().encodeToString(sunJceUnwrappedExtractableKey.getEncoded()));
     }
 
     /**
      * This method demonstrates "AESWrap/ECB/PKCS5Padding" by wrapping and unwrapping a key using HSM.
-     * @param caviumWrappingKey
+     * @param hsmWrappingKey
      * @param extractableKey
      * @throws InvalidKeyException
      * @throws NoSuchAlgorithmException
@@ -131,17 +120,17 @@ public class AESWrappingRunner {
      * @throws NoSuchPaddingException
      * @throws IllegalBlockSizeException
      */
-    private static void wrapWithPkcs5Pad(Key caviumWrappingKey, Key extractableKey)
+    private static void wrapWithPkcs5Pad(Key hsmWrappingKey, Key extractableKey)
             throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
 
         Cipher cipher = Cipher.getInstance("AESWrap/ECB/PKCS5Padding", "Cavium");
-        cipher.init(Cipher.WRAP_MODE, caviumWrappingKey);
+        cipher.init(Cipher.WRAP_MODE, hsmWrappingKey);
 
         // Wrap the extractable key using the wrappingKey
         byte[] wrappedBytes = cipher.wrap(extractableKey);
 
         // Unwrap using the HSM
-        cipher.init(Cipher.UNWRAP_MODE, caviumWrappingKey);
+        cipher.init(Cipher.UNWRAP_MODE, hsmWrappingKey);
         Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
 
         // Compare the two keys
@@ -152,7 +141,7 @@ public class AESWrappingRunner {
 
     /**
      * This method demonstrates "AESWrap/ECB/ZeroPadding" by wrapping and unwrapping a key using HSM.
-     * @param caviumWrappingKey
+     * @param hsmWrappingKey
      * @param extractableKey
      * @throws InvalidKeyException
      * @throws NoSuchAlgorithmException
@@ -160,17 +149,17 @@ public class AESWrappingRunner {
      * @throws NoSuchPaddingException
      * @throws IllegalBlockSizeException
      */
-    private static void wrapWithZeroPad(Key caviumWrappingKey, Key extractableKey)
+    private static void wrapWithZeroPad(Key hsmWrappingKey, Key extractableKey)
             throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
 
         Cipher cipher = Cipher.getInstance("AESWrap/ECB/ZeroPadding", "Cavium");
-        cipher.init(Cipher.WRAP_MODE, caviumWrappingKey);
+        cipher.init(Cipher.WRAP_MODE, hsmWrappingKey);
 
         // Wrap the extractable key using the wrappingKey
         byte[] wrappedBytes = cipher.wrap(extractableKey);
 
         // Unwrap using the HSM
-        cipher.init(Cipher.UNWRAP_MODE, caviumWrappingKey);
+        cipher.init(Cipher.UNWRAP_MODE, hsmWrappingKey);
         Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
 
         // Compare the two keys

--- a/src/main/java/com/amazonaws/cloudhsm/examples/AESWrappingRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/AESWrappingRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
  * software and associated documentation files (the "Software"), to deal in the Software
@@ -31,7 +31,7 @@ import java.util.Base64;
 import java.util.Arrays;
 
 /**
- * This sample demonstrates how to use AES to wrap and unwrap a key into and out of the HSM.
+ * This sample demonstrates how to use AESWrap to wrap and unwrap a key into and out of the HSM.
  */
 public class AESWrappingRunner {
     public static void main(String[] args) throws Exception {
@@ -45,41 +45,44 @@ public class AESWrappingRunner {
         /* We need an AES key to wrap and unwrap our extractable keys. */
         KeyGenerator keyGen = KeyGenerator.getInstance("AES");
         keyGen.init(256);
-        SecretKey wrappingKey = keyGen.generateKey();
+        SecretKey sunJceWrappingKey = keyGen.generateKey();
 
         /* Import this AES key into the HSM so we can wrap in the HSM and unwrap locally */
-        CaviumKey caviumWrappingKey = importWrappingKey(wrappingKey);
-        Util.persistKey(caviumWrappingKey);
+        CaviumKey hsmWrappingKey = importWrappingKey(sunJceWrappingKey);
+        Util.persistKey(hsmWrappingKey);
 
         // Extractable keys must be marked extractable.
         Key extractableKey = generateExtractableKey(256, "Test Extractable Key", false);
-        Key extractableKey2 = generateExtractableKey(192, "Test Extractable Key", false);
-        Key extractableKey3 = generateExtractableKey(128, "Test Extractable Key", false);
 
         try {
-            // Using the Cavium wrapping key, wrap and unwrap the extractable key.
-            wrap(caviumWrappingKey, extractableKey);
 
-            // Demonstrate the extra padding on the wrapped key.
-            // The customer needs to be aware of when moving keys from CloudHSM
-            // to their own crypto environment.
-            paddingDemonstration(caviumWrappingKey, wrappingKey, extractableKey);
-            paddingDemonstration(caviumWrappingKey, wrappingKey, extractableKey2);
-            paddingDemonstration(caviumWrappingKey, wrappingKey, extractableKey3);
+            System.out.printf("\nOriginal key before wrapping:\n %s\n",
+                                Base64.getEncoder().encodeToString(extractableKey.getEncoded()));
+
+            // Example to demonstrate wrap and unwrap with "AESWrap/ECB/NoPadding"
+            wrapWithNoPad(hsmWrappingKey, sunJceWrappingKey, extractableKey);
+
+            // Example to demonstrate wrap and unwrap with "AESWrap/ECB/PKCS5Padding"
+            wrapWithPkcs5Pad(hsmWrappingKey, extractableKey);
+
+            // Example to demonstrate wrap and unwrap with "AESWrap/ECB/ZeroPadding"
+            wrapWithZeroPad(hsmWrappingKey, extractableKey);
 
             // Clean up the keys.
-            Util.deleteKey((CaviumKey) caviumWrappingKey);
+            Util.deleteKey((CaviumKey) hsmWrappingKey);
             Util.deleteKey((CaviumKey) extractableKey);
+
         } catch (CFM2Exception ex) {
             ex.printStackTrace();
-            System.out.printf("Failed to delete key handles: %d\n", ((CaviumKey) wrappingKey).getHandle());
+            System.out.printf("Failed to delete key handles: %d\n", ((CaviumKey) hsmWrappingKey).getHandle());
         }
     }
 
     /**
-     * Using the wrapping key, wrap and unwrap the extractable key.
-     *
+     * The method demonstrates "AESWrap/ECB/NoPadding" by wrapping a key with Cavium provider
+     * and unwrapping the key with SunJCE provider.
      * @param wrappingKey
+     * @param sunJceWrappingKey
      * @param extractableKey
      * @throws InvalidKeyException
      * @throws NoSuchAlgorithmException
@@ -87,59 +90,93 @@ public class AESWrappingRunner {
      * @throws NoSuchPaddingException
      * @throws IllegalBlockSizeException
      */
-    private static void wrap(Key wrappingKey, Key extractableKey)
+    private static void wrapWithNoPad(Key hsmWrappingKey, Key sunJceWrappingKey, Key extractableKey)
             throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
 
-        Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding", "Cavium");
-        cipher.init(Cipher.WRAP_MODE, wrappingKey);
+        Cipher cipher = Cipher.getInstance("AESWrap/ECB/NoPadding", "Cavium");
+        cipher.init(Cipher.WRAP_MODE, hsmWrappingKey);
 
-        // Wrap the extractable key using the wrappingKey.
-        byte[] wrappedBytes = cipher.wrap(extractableKey);
+        // Wrap the extractable key using the wrappingKey
+        byte[] hsmWrappedBytes = cipher.wrap(extractableKey);
 
-        // Unwrap the wrapped key using the wrapping key.
-        cipher.init(Cipher.UNWRAP_MODE, wrappingKey);
-        Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
+        // Unwrap the wrapped key using the wrapping key
+        cipher.init(Cipher.UNWRAP_MODE, hsmWrappingKey);
+        Key hsmUnwrappedExtractableKey = cipher.unwrap(hsmWrappedBytes, "AES", Cipher.SECRET_KEY);
 
-        // Compare the two keys.
-        assert (Arrays.equals(extractableKey.getEncoded(), unwrappedExtractableKey.getEncoded()));
-        System.out.printf("\nVerified key when using the HSM to wrap and unwrap: %s\n", Base64.getEncoder().encodeToString(unwrappedExtractableKey.getEncoded()));
-    }
+        // Compare original key with HSM unwrapped key
+        assert (Arrays.equals(extractableKey.getEncoded(), hsmUnwrappedExtractableKey.getEncoded()));
+        System.out.printf("\nVerified key when using the HSM to wrap and unwrap with AESWrap/ECB/NoPadding:\n %s\n",
+                            Base64.getEncoder().encodeToString(hsmUnwrappedExtractableKey.getEncoded()));
 
-    /**
-     * This method demonstrates the PKCS#5 padding method that is used when wrapping keys through the JCE.
-     * When moving keys between providers it is important to know that this padding exists.
-     * @param caviumWrappingKey
-     * @param localWrappingKey
-     * @param extractableKey
-     * @throws InvalidKeyException
-     * @throws NoSuchAlgorithmException
-     * @throws NoSuchProviderException
-     * @throws NoSuchPaddingException
-     * @throws IllegalBlockSizeException
-     */
-    private static void paddingDemonstration(CaviumKey caviumWrappingKey, Key localWrappingKey, Key extractableKey)
-            throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
-
-        Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding", "Cavium");
-        cipher.init(Cipher.WRAP_MODE, caviumWrappingKey);
-
-        // Wrap the extractable key using the wrappingKey.
-        byte[] wrappedBytes = cipher.wrap(extractableKey);
-
-        // Create a SunJCE provider to unwrap the key, exposing the PKCS#5 padding.
+        // Create a SunJCE provider cipher instance to unwrap the key
         Cipher sunCipher = Cipher.getInstance("AESWrap", "SunJCE");
 
-        // Unwrap using the SunJCE.
-        sunCipher.init(Cipher.UNWRAP_MODE, localWrappingKey);
-        Key unwrappedExtractableKey = sunCipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
+        // Unwrap the hsm wrapped key using SunJCE
+        sunCipher.init(Cipher.UNWRAP_MODE, sunJceWrappingKey);
+        Key sunJceUnwrappedExtractableKey = sunCipher.unwrap(hsmWrappedBytes, "AES", Cipher.SECRET_KEY);
 
-        System.out.printf("\nWhen unwrapping with a different provider (SunJCE here), the unwrapped key still has PKCS#5 padding:\n");
-        byte[] unwrappedBytes = unwrappedExtractableKey.getEncoded();
-        for (int i = 0; i < unwrappedBytes.length; i++) {
-            System.out.printf("%02X", unwrappedBytes[i]);
-        }
+        // Compare original key with SunJCE unwrapped key
+        assert (Arrays.equals(extractableKey.getEncoded(), sunJceUnwrappedExtractableKey.getEncoded()));
+        System.out.printf("\nVerified key when using the HSM to wrap and SunJCE to unwrap with AESWrap/ECB/NoPadding:\n %s\n",
+                            Base64.getEncoder().encodeToString(sunJceUnwrappedExtractableKey.getEncoded()));
+    }
 
-        System.out.printf("\nYou can see the PKCS#5 padding bytes at the end of the unwrapped key. This padding must be stripped befure using the key.\n");
+    /**
+     * This method demonstrates "AESWrap/ECB/PKCS5Padding" by wrapping and unwrapping a key using HSM.
+     * @param caviumWrappingKey
+     * @param extractableKey
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws NoSuchProviderException
+     * @throws NoSuchPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    private static void wrapWithPkcs5Pad(Key caviumWrappingKey, Key extractableKey)
+            throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
+
+        Cipher cipher = Cipher.getInstance("AESWrap/ECB/PKCS5Padding", "Cavium");
+        cipher.init(Cipher.WRAP_MODE, caviumWrappingKey);
+
+        // Wrap the extractable key using the wrappingKey
+        byte[] wrappedBytes = cipher.wrap(extractableKey);
+
+        // Unwrap using the HSM
+        cipher.init(Cipher.UNWRAP_MODE, caviumWrappingKey);
+        Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
+
+        // Compare the two keys
+        assert (Arrays.equals(extractableKey.getEncoded(), unwrappedExtractableKey.getEncoded()));
+        System.out.printf("\nVerified key when using the HSM to wrap and unwrap with AESWrap/ECB/PKCS5Padding:\n %s\n",
+                            Base64.getEncoder().encodeToString(unwrappedExtractableKey.getEncoded()));
+    }
+
+    /**
+     * This method demonstrates "AESWrap/ECB/ZeroPadding" by wrapping and unwrapping a key using HSM.
+     * @param caviumWrappingKey
+     * @param extractableKey
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws NoSuchProviderException
+     * @throws NoSuchPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    private static void wrapWithZeroPad(Key caviumWrappingKey, Key extractableKey)
+            throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, IllegalBlockSizeException {
+
+        Cipher cipher = Cipher.getInstance("AESWrap/ECB/ZeroPadding", "Cavium");
+        cipher.init(Cipher.WRAP_MODE, caviumWrappingKey);
+
+        // Wrap the extractable key using the wrappingKey
+        byte[] wrappedBytes = cipher.wrap(extractableKey);
+
+        // Unwrap using the HSM
+        cipher.init(Cipher.UNWRAP_MODE, caviumWrappingKey);
+        Key unwrappedExtractableKey = cipher.unwrap(wrappedBytes, "AES", Cipher.SECRET_KEY);
+
+        // Compare the two keys
+        assert (Arrays.equals(extractableKey.getEncoded(), unwrappedExtractableKey.getEncoded()));
+        System.out.printf("\nVerified key when using the HSM to wrap and unwrap with AESWrap/ECB/ZeroPadding:\n %s\n",
+                            Base64.getEncoder().encodeToString(unwrappedExtractableKey.getEncoded()));
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
* Updated AESWrapping sample to include examples on using following mechanisms:
  * AESWrap/ECB/NoPadding
  * AESWrap/ECB/PKCS5Padding
  * AESWrap/ECB/ZeroPadding

* Removed usage of AES/CBC/* mechanism for Wrapping and UnWrapping

* Testing *
```
$java -ea -Djava.library.path=/opt/cloudhsm/lib/ -jar target/assembly/aes-wrapping-runner.jar

Original key before wrapping:
 8JxVG/0d4gduS34Y7IY2AVUX91Cpt0J/JWMF+AvGCHE=

Verified key when using the HSM to wrap and unwrap with AESWrap/ECB/NoPadding:
 8JxVG/0d4gduS34Y7IY2AVUX91Cpt0J/JWMF+AvGCHE=

Verified key when using the HSM to wrap and unwrap with AESWrap/ECB/PKCS5Padding:
 8JxVG/0d4gduS34Y7IY2AVUX91Cpt0J/JWMF+AvGCHE=

Verified key when using the HSM to wrap and unwrap with AESWrap/ECB/ZeroPadding:
 8JxVG/0d4gduS34Y7IY2AVUX91Cpt0J/JWMF+AvGCHE=
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
