### PR TITLE
Update CloudHSM Client latest and log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmVersion>3.1.0</cloudhsmVersion>
+                <cloudhsmVersion>3.1.2</cloudhsmVersion>
                 <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-${cloudhsmVersion}.jar</cloudhsmJarPath>
             </properties>
         </profile>
@@ -41,9 +41,9 @@
                         <configuration>
                             <groupId>org.apache.logging.log4j-core</groupId>
                             <artifactId>log4j-core</artifactId>
-                            <version>2.8</version>
+                            <version>2.13.3</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/log4j-core-2.8.jar</file>
+                            <file>/opt/cloudhsm/java/log4j-core-2.13.3.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -56,9 +56,9 @@
                         <configuration>
                             <groupId>org.apache.logging.log4j-api</groupId>
                             <artifactId>log4j-api</artifactId>
-                            <version>2.8</version>
+                            <version>2.13.3</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/log4j-api-2.8.jar</file>
+                            <file>/opt/cloudhsm/java/log4j-api-2.13.3.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -928,12 +928,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j-core</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j-api</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>com.cavium</groupId>


### PR DESCRIPTION
*Issue #, if available:*
- Upgrade log4j from version 2.8 to 2.13.3 in accordance with client upgrade 
- Client 3.1.0 --> 3.1.2

*Description of changes:*
Upgraded client version and log4j version in the pom.xml file

#### Testing

Tested change on an ec2 instance with client version 3.1.2 installed
Testing environment: Amazon Linux 2 EC2 instance


--------------
```
[ec2-user] /home/ec2-user/aws-cloudhsm-jce-examples (0)
➜  yum list installed | grep cloudhsm
cloudhsm-client.x86_64             3.1.2-1.el6                       installed
cloudhsm-client-jce.x86_64         3.1.2-1.el6                       installed

[ec2-user] /home/ec2-user/aws-cloudhsm-jce-examples (0)
➜  ls /opt/cloudhsm/java/
cloudhsm-test-3.1.2.jar  junit.jar             log4j-core-2.13.3.jar
cloudhsm-3.1.2.jar    hamcrest-all-1.3.jar     log4j-api-2.13.3.jar
```
--------------

Test Run is attached:
[jce-samples-test.txt](https://github.com/aws-samples/aws-cloudhsm-jce-examples/files/5004229/jce-samples-test.txt)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
