### PR TITLE
Fix maven package goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmVersion>3.1.2</cloudhsmVersion>
+                <cloudhsmVersion>3.2.1</cloudhsmVersion>
                 <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-${cloudhsmVersion}.jar</cloudhsmJarPath>
             </properties>
         </profile>
@@ -39,7 +39,7 @@
                         </goals>
                         <phase>validate</phase>
                         <configuration>
-                            <groupId>org.apache.logging.log4j-core</groupId>
+                            <groupId>org.apache.logging.log4j</groupId>
                             <artifactId>log4j-core</artifactId>
                             <version>2.13.3</version>
                             <packaging>jar</packaging>
@@ -54,7 +54,7 @@
                         </goals>
                         <phase>validate</phase>
                         <configuration>
-                            <groupId>org.apache.logging.log4j-api</groupId>
+                            <groupId>org.apache.logging.log4j</groupId>
                             <artifactId>log4j-api</artifactId>
                             <version>2.13.3</version>
                             <packaging>jar</packaging>
@@ -926,12 +926,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.logging.log4j-core</groupId>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.13.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j-api</groupId>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.13.3</version>
         </dependency>
@@ -939,6 +939,8 @@
             <groupId>com.cavium</groupId>
             <artifactId>cloudhsm</artifactId>
             <version>${cloudhsmVersion}</version>
+            <scope>system</scope>
+            <systemPath>/opt/cloudhsm/java/cloudhsm-${cloudhsmVersion}.jar</systemPath>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- update groupId for log4j
- update cloudhsm dependency  definition

*Issue #, if available:*

_mvn clean package_ command fails with following error description.

`[ERROR] Failed to execute goal on project aws-cloudhsm-jce-examples: Could not resolve dependencies for project com.amazonaws.cloudhsm.examples:aws-cloudhsm-jce-examples:jar:1.0-SNAPSHOT: The following artifacts could not be resolved: org.apache.logging.log4j-core:log4j-core:jar:2.13.3, org.apache.logging.log4j-api:log4j-api:jar:2.13.3, com.cavium:cloudhsm:jar:3.2.1: Failure to find org.apache.logging.log4j-core:log4j-core:jar:2.13.3 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced `

*Description of changes:*
Upgraded client version, log4j version and location of cloudhsm jar in the pom.xml file

This will fix the dependency resolution failures to successfully execute the maven package goal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
