### PR TITLE
Updated log4j to 2.17 and client to 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <cloudhsmVersion>3.4.2</cloudhsmVersion>
+                <cloudhsmVersion>3.4.3</cloudhsmVersion>
                 <cloudhsmJarPath>/opt/cloudhsm/java/cloudhsm-${cloudhsmVersion}.jar</cloudhsmJarPath>
             </properties>
         </profile>
@@ -41,9 +41,9 @@
                         <configuration>
                             <groupId>org.apache.logging.log4j-core</groupId>
                             <artifactId>log4j-core</artifactId>
-                            <version>2.16.0</version>
+                            <version>2.17.0</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/log4j-core-2.16.0.jar</file>
+                            <file>/opt/cloudhsm/java/log4j-core-2.17.0.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -56,9 +56,9 @@
                         <configuration>
                             <groupId>org.apache.logging.log4j-api</groupId>
                             <artifactId>log4j-api</artifactId>
-                            <version>2.16.0</version>
+                            <version>2.17.0</version>
                             <packaging>jar</packaging>
-                            <file>/opt/cloudhsm/java/log4j-api-2.16.0.jar</file>
+                            <file>/opt/cloudhsm/java/log4j-api-2.17.0.jar</file>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>
@@ -928,12 +928,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j-core</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j-api</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>com.cavium</groupId>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updated log4j version to 2.17 and CloudHSM client version to 3.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
