### PR TITLE
Add private exponent and token attributes to RSA KeyAttributesMap in ImportKey sample

### DIFF
--- a/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
+++ b/src/main/java/com/amazonaws/cloudhsm/examples/KeyUtilitiesRunner.java
@@ -249,6 +249,7 @@ public class KeyUtilitiesRunner {
         // Add key data for the key to be imported
         KeyAttributesMap keySpec = new KeyAttributesMapBuilder()
             .put(KeyAttribute.MODULUS, rsaKey.getModulus().toByteArray())
+            .put(KeyAttribute.PRIVATE_EXPONENT, rsaKey.getPrivateExponent().toByteArray())
             .put(KeyAttribute.PUBLIC_EXPONENT, rsaKey.getPublicExponent().toByteArray())
             .put(KeyAttribute.PRIME_P, rsaKey.getPrimeP().toByteArray())
             .put(KeyAttribute.PRIME_Q, rsaKey.getPrimeQ().toByteArray())
@@ -259,6 +260,10 @@ public class KeyUtilitiesRunner {
 
         // Add additional key related attributes
         keySpec.put(KeyAttribute.LABEL, keyLabel);
+
+        // The imported key will be ephemeral; it will be deleted from the HSM when the
+        // application exits. To persist the key you must set this attribute to true.
+        keySpec.put(KeyAttribute.TOKEN, false);
 
         try {
             KeyFactory keyFactory = KeyFactory.getInstance("RSA", CloudHsmProvider.PROVIDER_NAME);


### PR DESCRIPTION
*Issue #, if available:*
The RSA Private Key import sample was missing the PRIVATE_EXPONENT attribute in order to successfully import into the HSM.

*Description of changes:*
* Added the PRIVATE_EXPONENT attribute to the RSA KeyAttributesMap for import
* Added TOKEN attribute to specify that this import will be ephemeral

*Testing*
```
openssl genrsa -out rsa_private_key.pem -f4 2048
openssl rsa -in rsa_private_key.pem -noout -check
openssl pkcs8 -topk8 -in rsa_private_key.pem -inform pem -out rsa_private_key_pkcs8.pem -outform pem -nocrypt
openssl rsa -in rsa_private_key_pkcs8.pem -noout -check
java -ea -Djava.library.path=/opt/cloudhsm/lib/ -cp ".:/opt/cloudhsm/java/*" -jar target/assembly/key-utility-runner.jar --import-rsa-pem rsa_private_key_pkcs8.pem
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
