### PR TITLE
Upgrade Bouncy Castle 1.83 → 1.84 (4 CVEs) and add missing verify steps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <keystore.test.password>changeit</keystore.test.password>
     </properties>
 
     <profiles>
@@ -792,8 +793,11 @@
                                 <argument>-enableassertions</argument>
                                 <argument>-jar</argument>
                                 <argument>target/assembly/cloudhsm-keystore-runner.jar</argument>
-                                <argument>--method</argument>
-                                <argument>environment</argument>
+                                <argument>--store</argument>
+                                <argument>${java.io.tmpdir}/cloudhsm-keystore-test.jks</argument>
+                                <argument>--password</argument>
+                                <argument>${keystore.test.password}</argument>
+                                <argument>--run-all</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -995,6 +999,40 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>verify-mldsa-ops</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-enableassertions</argument>
+                                <argument>-jar</argument>
+                                <argument>target/assembly/mldsa-operations-runner.jar</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify-mldsa-keystore</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-enableassertions</argument>
+                                <argument>-jar</argument>
+                                <argument>target/assembly/mldsa-keystore-runner.jar</argument>
+                                <argument>--store</argument>
+                                <argument>${java.io.tmpdir}/mldsa-keystore-test.jks</argument>
+                                <argument>--password</argument>
+                                <argument>${keystore.test.password}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -1010,12 +1048,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>1.84</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Security

Bump bcprov-jdk18on and bcpkix-jdk18on from 1.83 to 1.84, fixing:
- CVE-2025-14813 (Critical) in bcprov-jdk18on
- CVE-2026-5598 (High) in bcprov-jdk18on
- CVE-2026-0636 (Moderate) in bcprov-jdk18on
- CVE-2026-5588 (Moderate) in bcpkix-jdk18on

Supersedes Dependabot PRs #109 and #111.

## Verify coverage improvements

Add verify steps for ML-DSA samples that were built but never exercised:
- verify-mldsa-ops: runs MldsaOperationsRunner (defaults to ML-DSA-44,
  exercises key gen, pure sign/verify, external MU sign/verify, key delete)
- verify-mldsa-keystore: runs MldsaKeyStoreExampleRunner with --store and
  --password args, exercises key gen on HSM, self-signed cert via Bouncy
  Castle, and keystore store/load

Fix verify-cloudhsm-keystore: replace incorrect --method environment arg
(a LoginRunner arg copied by mistake, silently ignored — sample printed
help and exited 0 without exercising the keystore) with --store, --password,
and --run-all to actually run the keystore sample.

Add keystore.test.password Maven property (default: changeit) used by both
keystore verify steps. Overridable via -Dkeystore.test.password=<value>.

## Testing

Tested against two CloudHSM clusters in ca-central-1:
- cluster-olmtyvuedhr (NON_FIPS, hsm2m.medium): 22/22 verify steps pass
- cluster-tpgqfk5t4wm (FIPS, hsm2m.medium): 18/22 pass; 4 pre-existing
  FIPS-mode failures unrelated to this change (DES-ECB, DES-CBC, EdDSA ops,
  EdDSA import — all non-FIPS-approved algorithms)

All 4 BC-importing samples (KeyStoreExampleRunner, MldsaKeyStoreExampleRunner,
ECImportKey, EdDSAImportKey) verified with BC 1.84 on both clusters.